### PR TITLE
2019120300 release code.

### DIFF
--- a/lang/en/atto_panoptobutton.php
+++ b/lang/en/atto_panoptobutton.php
@@ -32,4 +32,4 @@ $string['insert'] = 'Insert';
 $string['cancel'] = 'Cancel';
 $string['defaultserver'] = 'Default server for retrieving videos (used when not in a provisioned course)';
 $string['panoptobutton:visible'] = 'Visible';
-$string['privacy:metadata'] = '';
+$string['privacy:metadata'] = 'No user data is stored by this plugin';

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 // The current plugin version (Date: YYYYMMDDXX).
-$plugin->version   = 2019081200;
+$plugin->version   = 2019120300;
 
 // Requires this Moodle version - 2.7.
 $plugin->requires  = 2014051200;


### PR DESCRIPTION
This is an optional version of the Panopto button for Atto plug-in. Those who already use  2019081200 do not need to update this version.

- Updated code format to better support OpenLMS requirements.
