### PR TITLE
Fix lint error max-len

### DIFF
--- a/yui/src/button/js/button.js
+++ b/yui/src/button/js/button.js
@@ -290,7 +290,8 @@ var COMPONENTNAME = 'atto_panoptobutton',
 
                             thumbnailChunk += "<a href='https://" + servername + '/Panopto/Pages/Viewer.aspx' +
                                 idChunk + "' target='_blank'>" +
-                                "<img width='128' height='72' src='https://" + servername + '/Panopto/PublicAPI/SessionPreviewImage?id=' +
+                                "<img width='128' height='72' src='https://" +
+                                servername + '/Panopto/PublicAPI/SessionPreviewImage?id=' +
                                 ids[i] + "'></img></a><br></div>";
 
                             objectstring += "<div style='position: relative;'>" +


### PR DESCRIPTION
Fixes annoying lint error
```
lib/editor/atto/plugins/panoptobutton/yui/src/button/js/button.js
  293:1  error  This line has a length of 138. Maximum allowed is 132  max-len
```